### PR TITLE
fix empty strings for closed positions if not a withdraw

### DIFF
--- a/go-indexer/database/composite-types.go
+++ b/go-indexer/database/composite-types.go
@@ -1,10 +1,10 @@
 package database
 
 type PositionUpdate struct {
-	Id                      string `json:"id"`
-	IsTerminated            bool   `json:"is_terminated"`
-	PositionEndHeight       int64  `json:"position_end_height"`
-	WithdrawReceiverAddress string `json:"withdraw_receiver_address"`
+	Id                      string  `json:"id"`
+	IsTerminated            bool    `json:"is_terminated"`
+	PositionEndHeight       int64   `json:"position_end_height"`
+	WithdrawReceiverAddress *string `json:"withdraw_receiver_address"`
 }
 
 func ToPositionUpdate(u PublicPositionsUpdate) PositionUpdate {
@@ -13,24 +13,26 @@ func ToPositionUpdate(u PublicPositionsUpdate) PositionUpdate {
 		Id:                      *u.Id,
 		IsTerminated:            *u.IsTerminated,
 		PositionEndHeight:       *u.PositionEndHeight,
-		WithdrawReceiverAddress: *u.WithdrawReceiverAddress,
+		WithdrawReceiverAddress: u.WithdrawReceiverAddress,
 	}
 }
 
 type PositionInsert struct {
-	PositionIndexId     int64  `json:"position_index_id"`
-	OwnerAddress        string `json:"owner_address"`
-	ContractAddress     string `json:"contract_address"`
-	AmountShares        string `json:"amount_shares"`
-	PositionStartHeight int64  `json:"position_start_height"`
+	PositionIndexId         int64   `json:"position_index_id"`
+	OwnerAddress            string  `json:"owner_address"`
+	ContractAddress         string  `json:"contract_address"`
+	AmountShares            string  `json:"amount_shares"`
+	PositionStartHeight     int64   `json:"position_start_height"`
+	WithdrawReceiverAddress *string `json:"withdraw_receiver_address"`
 }
 
 func ToPositionInsert(u PublicPositionsInsert) PositionInsert {
 	return PositionInsert{
-		PositionIndexId:     u.PositionIndexId,
-		OwnerAddress:        u.OwnerAddress,
-		ContractAddress:     u.ContractAddress,
-		AmountShares:        u.AmountShares,
-		PositionStartHeight: u.PositionStartHeight,
+		PositionIndexId:         u.PositionIndexId,
+		OwnerAddress:            u.OwnerAddress,
+		ContractAddress:         u.ContractAddress,
+		AmountShares:            u.AmountShares,
+		PositionStartHeight:     u.PositionStartHeight,
+		WithdrawReceiverAddress: nil,
 	}
 }

--- a/go-indexer/transformer/position-transformer.go
+++ b/go-indexer/transformer/position-transformer.go
@@ -262,16 +262,11 @@ func (p *PositionTransformer) UpdatePosition(
 
 	p.logger.Debug("insert value: %v", insert)
 
-	var receiverAddress *string = nil
-	if input.WithdrawReceiverAddress != nil {
-		receiverAddress = input.WithdrawReceiverAddress
-	}
-
 	update = database.ToPositionUpdate(database.PublicPositionsUpdate{
 		Id:                      &input.CurrentPosition.Id,
 		IsTerminated:            &isTerminated,
 		PositionEndHeight:       &endHeight,
-		WithdrawReceiverAddress: receiverAddress,
+		WithdrawReceiverAddress: input.WithdrawReceiverAddress,
 	})
 
 	return insert, &update, nil

--- a/go-indexer/transformer/position-transformer.go
+++ b/go-indexer/transformer/position-transformer.go
@@ -131,11 +131,12 @@ func (p *PositionTransformer) ComputeTransfer(args ProcessPosition, senderPositi
 
 		// update receiver position
 		insert, update, err := p.UpdatePosition(UpdatePositionInput{
-			CurrentPosition: receiverPosition,
-			Address:         args.ReceiverAddress,
-			AmountShares:    args.AmountShares,
-			BlockNumber:     args.BlockNumber,
-			IsAddition:      true,
+			CurrentPosition:         receiverPosition,
+			Address:                 args.ReceiverAddress,
+			AmountShares:            args.AmountShares,
+			BlockNumber:             args.BlockNumber,
+			IsAddition:              true,
+			WithdrawReceiverAddress: nil,
 		}, &positionIndexId)
 		if err != nil {
 			p.logger.Error("Error updating position: %v", err)
@@ -261,16 +262,16 @@ func (p *PositionTransformer) UpdatePosition(
 
 	p.logger.Debug("insert value: %v", insert)
 
-	var receiverAddress string
+	var receiverAddress *string = nil
 	if input.WithdrawReceiverAddress != nil {
-		receiverAddress = *input.WithdrawReceiverAddress
+		receiverAddress = input.WithdrawReceiverAddress
 	}
 
 	update = database.ToPositionUpdate(database.PublicPositionsUpdate{
 		Id:                      &input.CurrentPosition.Id,
 		IsTerminated:            &isTerminated,
 		PositionEndHeight:       &endHeight,
-		WithdrawReceiverAddress: &receiverAddress,
+		WithdrawReceiverAddress: receiverAddress,
 	})
 
 	return insert, &update, nil

--- a/go-indexer/transformer/position-transformer_test.go
+++ b/go-indexer/transformer/position-transformer_test.go
@@ -93,9 +93,10 @@ func TestProcessDeposit(t *testing.T) {
 
 		var expectedUpdates = []database.PositionUpdate{
 			{
-				Id:                receiverPosition.Id,
-				PositionEndHeight: 1999,
-				IsTerminated:      false,
+				Id:                      receiverPosition.Id,
+				PositionEndHeight:       1999,
+				IsTerminated:            false,
+				WithdrawReceiverAddress: nil,
 			},
 		}
 		var expectedInserts = []database.PositionInsert{
@@ -148,9 +149,10 @@ func TestProcessTransfer(t *testing.T) {
 
 		var expectedUpdates = []database.PositionUpdate{
 			{
-				Id:                senderPosition.Id,
-				PositionEndHeight: 1999,
-				IsTerminated:      true,
+				Id:                      senderPosition.Id,
+				PositionEndHeight:       1999,
+				IsTerminated:            true,
+				WithdrawReceiverAddress: nil,
 			},
 		}
 
@@ -205,14 +207,16 @@ func TestProcessTransfer(t *testing.T) {
 
 		var expectedUpdates = []database.PositionUpdate{
 			{
-				Id:                receiverPosition.Id,
-				PositionEndHeight: 1999,
-				IsTerminated:      false,
+				Id:                      receiverPosition.Id,
+				PositionEndHeight:       1999,
+				IsTerminated:            false,
+				WithdrawReceiverAddress: nil,
 			},
 			{
-				Id:                senderPosition.Id,
-				PositionEndHeight: 1999,
-				IsTerminated:      true,
+				Id:                      senderPosition.Id,
+				PositionEndHeight:       1999,
+				IsTerminated:            true,
+				WithdrawReceiverAddress: nil,
 			},
 		}
 
@@ -274,14 +278,16 @@ func TestProcessTransfer(t *testing.T) {
 
 		var expectedUpdates = []database.PositionUpdate{
 			{
-				Id:                receiverPosition.Id,
-				PositionEndHeight: 1999,
-				IsTerminated:      false,
+				Id:                      receiverPosition.Id,
+				PositionEndHeight:       1999,
+				IsTerminated:            false,
+				WithdrawReceiverAddress: nil,
 			},
 			{
-				Id:                senderPosition.Id,
-				PositionEndHeight: 1999,
-				IsTerminated:      false,
+				Id:                      senderPosition.Id,
+				PositionEndHeight:       1999,
+				IsTerminated:            false,
+				WithdrawReceiverAddress: nil,
 			},
 		}
 
@@ -319,7 +325,7 @@ func TestProcessWithdraw(t *testing.T) {
 				Id:                      currentPosition.Id,
 				PositionEndHeight:       1999,
 				IsTerminated:            false,
-				WithdrawReceiverAddress: NeutronAddress1,
+				WithdrawReceiverAddress: toStringPtr(NeutronAddress1),
 			},
 		}
 		var expectedInserts = []database.PositionInsert{
@@ -362,7 +368,7 @@ func TestProcessWithdraw(t *testing.T) {
 				Id:                      senderPosition.Id,
 				PositionEndHeight:       1999,
 				IsTerminated:            true,
-				WithdrawReceiverAddress: NeutronAddress1,
+				WithdrawReceiverAddress: toStringPtr(NeutronAddress1),
 			},
 		}
 
@@ -417,9 +423,10 @@ func TestUpdatePosition(t *testing.T) {
 		}
 
 		expectedUpdate := &database.PositionUpdate{
-			Id:                currentPosition.Id,
-			PositionEndHeight: 1999,
-			IsTerminated:      false,
+			Id:                      currentPosition.Id,
+			PositionEndHeight:       1999,
+			IsTerminated:            false,
+			WithdrawReceiverAddress: nil,
 		}
 
 		assert.Equal(t, expectedInsert, insert)
@@ -448,9 +455,10 @@ func TestUpdatePosition(t *testing.T) {
 		}, toInt64Ptr(0))
 
 		expectedUpdate := &database.PositionUpdate{
-			Id:                currentPosition.Id,
-			PositionEndHeight: 1999,
-			IsTerminated:      true,
+			Id:                      currentPosition.Id,
+			PositionEndHeight:       1999,
+			IsTerminated:            true,
+			WithdrawReceiverAddress: nil,
 		}
 
 		assert.Nil(t, insert)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for an optional withdraw receiver address in position records, allowing this field to be left blank when not applicable.

- **Bug Fixes**
  - Improved handling of optional withdraw receiver address to prevent unintended errors when the value is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->