### PR TITLE
restart systemd service on failure up to 5 times

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,8 +69,14 @@
                 supabase db push --db-url "$INDEXER_POSTGRES_CONNECTION_STRING"
                 cd -
               '';
+              unitConfig = {
+                StartLimitBurst = 5;
+                StartLimitIntervalSec = "10m";
+              };
               serviceConfig = {
                 ExecStart = "${lib.getExe package} prod";
+                Restart = "on-failure";
+                RestartSec = "1s";
                 StateDirectory = "vault-indexer";
                 WorkingDirectory = "/var/lib/vault-indexer";
               };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved the reliability of the vault-indexer service by enabling automatic restarts on failure and adjusting service restart rate limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->