### PR TITLE
chore(flake): add restart linear backoff

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,8 @@
                 ExecStart = "${lib.getExe package} prod";
                 Restart = "on-failure";
                 RestartSec = "1s";
+                RestartSteps = 40;
+                RestartMaxDelaySec = "20min";
                 StateDirectory = "vault-indexer";
                 WorkingDirectory = "/var/lib/vault-indexer";
               };


### PR DESCRIPTION
Adds linear backoff to restarts of the indexer.
Current configuration will result in increasing the time between restarts by 30 sec up to 40 times with a max restart delay of 20 min.